### PR TITLE
Latest version of snakemake does not work

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - bioconductor-genomeinfodb
   - bioconductor-genomeinfodbdata
   - bioconductor-genomeinfodbdata
-  - snakemake
+  - snakemake=6.1.0
   - pandas
 
   # For train-predict


### PR DESCRIPTION
This change makes it so anaconda installs snakemake 6.1.0 instead of the latest version (6.4.1). The latest version does not seem to work.